### PR TITLE
اصلاح مشكلة عدم نقل مكاتب ألف الى مجلد C:/Alif3/aliflib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,3 +65,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Alif Compiler Source Code
 add_subdirectory(${AlifProject_SOURCE_DIR}/src Alif)
+
+# --[ Copping Files ] ----------------------------------------------------------------
+
+if (WIN32)
+    if(EXISTS "C:/Alif3/")
+
+        file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/aliflib/ DESTINATION C:/Alif3/aliflib/)
+
+    endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,13 +65,3 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Alif Compiler Source Code
 add_subdirectory(${AlifProject_SOURCE_DIR}/src Alif)
-
-# --[ Copping Files ] ----------------------------------------------------------------
-
-if (WIN32)
-    if(EXISTS "C:/Alif3/")
-
-        file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/aliflib/ DESTINATION C:/Alif3/aliflib/)
-
-    endif()
-endif()

--- a/aliflib/alifcore.cc
+++ b/aliflib/alifcore.cc
@@ -19,8 +19,8 @@
 
 #ifdef _WIN32
 #include <tchar.h>
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 #elif __APPLE__
 // ...
 #else

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,12 @@ if(UNIX)
 	install (DIRECTORY ${AlifProject_SOURCE_DIR}/aliflib DESTINATION lib)
 endif (UNIX)
 
+if(WIN32)
+	message("[*] Initializing installation settings...")
+	install (TARGETS ${Info_App} DESTINATION C:/Alif3)
+	install (DIRECTORY ${AlifProject_SOURCE_DIR}/aliflib DESTINATION C:/Alif3)
+endif ()
+
 # --[ Copy Examples ] ------------------------------------------------------------
 
 file(COPY ${AlifProject_SOURCE_DIR}/examples DESTINATION ${CMAKE_BINARY_DIR}/)

--- a/src/alif.cpp
+++ b/src/alif.cpp
@@ -37,6 +37,7 @@
 // OS Include ***************************************************
 
 	#ifdef _WIN32
+		#include <winsock2.h>
 		#include <windows.h>
 		#include <tchar.h>
 	#elif  __APPLE__
@@ -4999,11 +5000,12 @@
 		#include <direct.h> // getcwd (Get current working directory)
 		#define GetCurrentDir _getcwd
 
+		#include <winsock2.h>
 		#include <windows.h> // Get Working Path by Win32 API
 
 		//#include <w32api.h>
 		//#include <Winbase.h>
-		#include <windows.h> // Get Absolute Path by Win32 API
+		//#include <windows.h> // Get Absolute Path by Win32 API
 		#include <stdlib.h> // Get Temp envirenemt by Win32 API getenv()
 
 		std::string GET_WORKING_PATH_WIN32()


### PR DESCRIPTION
<div dir = rtl>

في الوندوز عند بناء المترجم لم يقم بتحديث الملفات الخاصة بمكاتب ألف في `C:/Alif3/aliflib`   
وكان يجب القيام بنسخ المجلد `aliflib` من المترجم يدويا إلى مجلد ألف في `C:/Alif3` 
لذا قمت بإصلاح المشكلة وجعل عملية النقل عملية تلقائية اثناء البناء  
